### PR TITLE
Merging multi-threaded voxels by weighted average

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.20)
 project(pcl_test)
 
+set(CMAKE_BUILD_TYPE "Release")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -g -pthread")
+
 set(CMAKE_CXX_STANDARD 11)
 
 find_package(PCL REQUIRED)


### PR DESCRIPTION
I implemented weighted average merging based on your code. The main changes are as follows:
- Implemented multi-threaded weighted average merge;
- Replace std::sort with boost::sort::spreadsort::integer_sort. The latter is nearly twice as fast as the former.
- After adding release in cmake, the speed will increase ten times.
The output of the program is exactly the same as the output of the official version of pcl. In debug mode, 4 threads will bring nearly 3 times improvement. But after switching to release mode, the improvement is not obvious. Maybe the m1 pro chip CPU is unstable. I will check the performance on the intel machine tomorrow.